### PR TITLE
Link to readme added to display on PYPI page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [tool.poetry]
   name = "pieces_os_client"
-  version = "1.2.7"
+  version = "1.2.8"
   description = "A powerful code engine package for writing applications on top of Pieces OS"
   authors = [
     "Pieces <development@pieces.app>"
   ]
   license = "MIT"
+  readme = "README.md"
 
 [tool.poetry.dependencies]
   python = ">=3.8"


### PR DESCRIPTION
This should be pretty small just adds in some poetry configuration to display the proper data on our PYPI page. This was in a previous release but must have just been overwritten and would love to get it in. 

