### PR TITLE
Add Unit Tests for Context Class in Pieces OS Client

### DIFF
--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -9,7 +9,7 @@ import os
 if TYPE_CHECKING:
 	from . import PiecesClient
 
-class TestContext(unittest.TestCase):
+class BasicTestContext(unittest.TestCase):
     def setUp(self):
         self.mock_client = Mock()
         self.context = Context(self.mock_client)
@@ -42,7 +42,7 @@ class TestContext(unittest.TestCase):
         self.assertEqual(self.context.paths, [])
         self.assertEqual(self.context.assets, [])
         self.assertEqual(self.context.messages, [])
-	
+
     @patch('pieces_os_client.wrapper.context.os.path.exists', return_value=True)
     @patch('pieces_os_client.wrapper.basic_identifier.asset.AssetSnapshot.identifiers_snapshot')
     @patch('pieces_os_client.wrapper.basic_identifier.message.BasicMessage')
@@ -150,3 +150,4 @@ class TestContext(unittest.TestCase):
             messages=FlattenedConversationMessages(iterable=[])
         )
         self.context.pieces_client.qgpt_api.relevance.assert_called_once()
+

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -16,5 +16,15 @@ class TestContext(unittest.TestCase):
         # Mock AssetSnapshot.pieces_client
         AssetSnapshot.pieces_client = MagicMock()
 
+    @patch('pieces_os_client.wrapper.basic_identifier.message.BasicMessage')
+    @patch('pieces_os_client.wrapper.basic_identifier.asset.BasicAsset')
+    def test_init(self, mock_basic_asset, mock_basic_message):
+        self.assertEqual(self.context.pieces_client, self.mock_client)
+        self.assertEqual(self.context.raw_assets, [])
+        self.assertEqual(self.context.paths, [])
+        self.assertEqual(self.context.assets, [])
+        self.assertEqual(self.context.messages, [])
+
+	
 
 

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -87,3 +87,16 @@ class TestContext(unittest.TestCase):
         result = Context._check_messages(messages)
         self.assertIsInstance(result, FlattenedConversationMessages)
         self.assertEqual(len(result.iterable), 2)
+
+    @patch('pieces_os_client.wrapper.basic_identifier.asset.AssetSnapshot.identifiers_snapshot')
+    @patch('pieces_os_client.wrapper.basic_identifier.asset.BasicAsset')
+    def test_check_assets(self, mock_basic_asset, mock_identifiers_snapshot):
+        mock_identifiers_snapshot.get.return_value = Mock()
+        mock_asset = MagicMock(spec=BasicAsset)
+        mock_asset.asset = "test_asset"
+        mock_basic_asset.return_value = mock_asset
+
+        assets = [mock_asset, mock_asset]
+        result = Context._check_assets(assets)
+        self.assertIsInstance(result, FlattenedAssets)
+        self.assertEqual(len(result.iterable), 2)

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -9,3 +9,12 @@ import os
 if TYPE_CHECKING:
 	from . import PiecesClient
 
+class TestContext(unittest.TestCase):
+    def setUp(self):
+        self.mock_client = Mock()
+        self.context = Context(self.mock_client)
+        # Mock AssetSnapshot.pieces_client
+        AssetSnapshot.pieces_client = MagicMock()
+
+
+

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -110,3 +110,13 @@ class TestContext(unittest.TestCase):
         mock_exists.return_value = False
         with self.assertRaises(ValueError):
             Context._check_paths(["/invalid"])
+
+    @patch('pieces_os_client.wrapper.basic_identifier.asset.AssetSnapshot.pieces_client')
+    @patch('pieces_os_client.wrapper.basic_identifier.asset.BasicAsset._get_seed')
+    def test_check_raw_assets(self, mock_get_seed, mock_pieces_client):
+        mock_seed = MagicMock()
+        mock_get_seed.return_value = mock_seed
+        raw_assets = ["test1", "test2"]
+        result = Context._check_raw_assets(raw_assets)
+        self.assertIsInstance(result, Seeds)
+        self.assertEqual(len(result.iterable), 2)

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -76,3 +76,14 @@ class TestContext(unittest.TestCase):
         self.assertFalse(self.context._check_relevant_existance())
         self.context.paths = ["/tmp"]
         self.assertTrue(self.context._check_relevant_existance())
+
+    @patch('pieces_os_client.wrapper.basic_identifier.message.BasicMessage')
+    def test_check_messages(self, mock_basic_message):
+        mock_message = MagicMock(spec=BasicMessage)
+        mock_message.message = "test_message"
+        mock_basic_message.return_value = mock_message
+
+        messages = [mock_message, mock_message]
+        result = Context._check_messages(messages)
+        self.assertIsInstance(result, FlattenedConversationMessages)
+        self.assertEqual(len(result.iterable), 2)

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -43,5 +43,32 @@ class TestContext(unittest.TestCase):
         self.assertEqual(self.context.assets, [])
         self.assertEqual(self.context.messages, [])
 	
+    @patch('pieces_os_client.wrapper.context.os.path.exists', return_value=True)
+    @patch('pieces_os_client.wrapper.basic_identifier.asset.AssetSnapshot.identifiers_snapshot')
+    @patch('pieces_os_client.wrapper.basic_identifier.message.BasicMessage')
+    @patch('pieces_os_client.wrapper.basic_identifier.asset.BasicAsset')
+    def test_get_relevant_dict(self, mock_basic_asset, mock_basic_message, mock_identifiers_snapshot, mock_exists):
+        mock_identifiers_snapshot.get.return_value = Mock()
+        mock_asset = MagicMock(spec=BasicAsset)
+        mock_message = MagicMock(spec=BasicMessage)
+        mock_basic_asset.return_value = mock_asset
+        mock_basic_message.return_value = mock_message
 
+        # Set the 'message' attribute on the mock_message
+        mock_message.message = "test message"
+
+        # Mock the _check_raw_assets method to return a valid Seeds object
+        self.context._check_raw_assets = MagicMock(return_value=Seeds(iterable=[]))
+
+        self.context.paths = ["/tmp"]
+        self.context.assets = [mock_asset]
+        self.context.raw_assets = ["test"]
+        self.context.messages = [mock_message]
+
+        result = self.context._get_relevant_dict()
+
+        self.assertEqual(result["paths"], ["/tmp"])
+        self.assertIsInstance(result["seed"], Seeds)
+        self.assertIsInstance(result["assets"], FlattenedAssets)
+        self.assertIsInstance(result["messages"], FlattenedConversationMessages)
 

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -120,3 +120,33 @@ class TestContext(unittest.TestCase):
         result = Context._check_raw_assets(raw_assets)
         self.assertIsInstance(result, Seeds)
         self.assertEqual(len(result.iterable), 2)
+
+    @patch('pieces_os_client.wrapper.context.QGPTRelevanceInput')
+    @patch('pieces_os_client.wrapper.basic_identifier.asset.AssetSnapshot.identifiers_snapshot')
+    def test_relevance_api(self, mock_identifiers_snapshot, mock_relevance_input):
+        mock_identifiers_snapshot.get.return_value = Mock()
+        self.context.pieces_client.qgpt_api.relevance.return_value.relevant = True
+        self.context.pieces_client.tracked_application.id = "test_app"
+        self.context.pieces_client.model_id = "test_model"
+
+        # Mock the _get_relevant_dict method to return a valid dictionary
+        self.context._get_relevant_dict = MagicMock(return_value={
+            "paths": [],
+            "seed": Seeds(iterable=[]),
+            "assets": FlattenedAssets(iterable=[]),
+            "messages": FlattenedConversationMessages(iterable=[])
+        })
+
+        result = self.context._relevance_api("test query")
+
+        self.assertTrue(result)
+        mock_relevance_input.assert_called_once_with(
+            query="test query",
+            application="test_app",
+            model="test_model",
+            paths=[],
+            seed=Seeds(iterable=[]),
+            assets=FlattenedAssets(iterable=[]),
+            messages=FlattenedConversationMessages(iterable=[])
+        )
+        self.context.pieces_client.qgpt_api.relevance.assert_called_once()

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -1,0 +1,11 @@
+import unittest
+from unittest.mock import Mock, patch, MagicMock
+from typing import List , TYPE_CHECKING
+from pieces_os_client import QGPTRelevanceInput, Seeds, FlattenedAssets, FlattenedConversationMessages
+from pieces_os_client.wrapper.basic_identifier import BasicAsset, BasicMessage
+from pieces_os_client.wrapper.basic_identifier.asset import AssetSnapshot
+from pieces_os_client.wrapper.context import Context
+import os
+if TYPE_CHECKING:
+	from . import PiecesClient
+

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -100,3 +100,13 @@ class TestContext(unittest.TestCase):
         result = Context._check_assets(assets)
         self.assertIsInstance(result, FlattenedAssets)
         self.assertEqual(len(result.iterable), 2)
+
+    @patch('os.path.exists')
+    def test_check_paths(self, mock_exists):
+        mock_exists.return_value = True
+        Context._check_paths(["/tmp"])
+        mock_exists.assert_called_once_with("/tmp")
+
+        mock_exists.return_value = False
+        with self.assertRaises(ValueError):
+            Context._check_paths(["/invalid"])

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -25,6 +25,23 @@ class TestContext(unittest.TestCase):
         self.assertEqual(self.context.assets, [])
         self.assertEqual(self.context.messages, [])
 
+    @patch('pieces_os_client.wrapper.basic_identifier.message.BasicMessage')
+    @patch('pieces_os_client.wrapper.basic_identifier.asset.BasicAsset')
+    def test_clear(self, mock_basic_asset, mock_basic_message):
+        mock_asset = MagicMock(spec=BasicAsset)
+        mock_message = MagicMock(spec=BasicMessage)
+        mock_basic_asset.return_value = mock_asset
+        mock_basic_message.return_value = mock_message
+
+        self.context.raw_assets = ["test"]
+        self.context.paths = ["test"]
+        self.context.assets = [mock_asset]
+        self.context.messages = [mock_message]
+        self.context.clear()
+        self.assertEqual(self.context.raw_assets, [])
+        self.assertEqual(self.context.paths, [])
+        self.assertEqual(self.context.assets, [])
+        self.assertEqual(self.context.messages, [])
 	
 
 

--- a/tests/test_basic_context.py
+++ b/tests/test_basic_context.py
@@ -72,3 +72,7 @@ class TestContext(unittest.TestCase):
         self.assertIsInstance(result["assets"], FlattenedAssets)
         self.assertIsInstance(result["messages"], FlattenedConversationMessages)
 
+    def test_check_relevant_existence(self):
+        self.assertFalse(self.context._check_relevant_existance())
+        self.context.paths = ["/tmp"]
+        self.assertTrue(self.context._check_relevant_existance())


### PR DESCRIPTION
## Description:
This PR introduces a comprehensive set of unit tests for the Context class in the Pieces OS Client. 

## Tests :

The tests cover the following methods:

- test_init: Verifies the initialization of the Context object.
- test_clear: Checks the clearing of assets and messages within the context.
- test_get_relevant_dict: Tests the retrieval of relevant dictionary data based on the context.
- test_check_relevant_existence: Validates the existence of relevant paths.
- test_check_messages: Confirms that messages are being properly handled and flattened.
- test_check_assets: Ensures that assets are correctly processed and flattened.
- test_check_paths: Verifies the validity of paths used within the context.
- test_check_raw_assets: Tests the handling of raw assets and their conversion into Seeds.
- test_relevance_api: Mocks and tests the relevance_api method for relevance checks.

## Screenshots :

Here is a screenshot of all test cases passing :

<img width="1049" alt="Screenshot 2024-09-04 at 3 10 53 PM" src="https://github.com/user-attachments/assets/85a3db7c-f413-48e4-8d0b-8f624a0a7359">
