### PR TITLE
fix ask web-socket

### DIFF
--- a/src/pieces_os_client/wrapper/websockets/ask_ws.py
+++ b/src/pieces_os_client/wrapper/websockets/ask_ws.py
@@ -73,5 +73,5 @@ class AskStreamWS(BaseWebsocket):
 				raise WebSocketConnectionClosedException()
 			self.ws.send(message.to_json())
 		except WebSocketConnectionClosedException:
-			self.on_open = lambda ws: ws.send(message.to_json())  # Send the message on opening
+			self.on_open_callback = lambda ws: ws.send(message.to_json())  # Send the message on opening
 			self.start()  # Start a new WebSocket since we are not connected to any


### PR DESCRIPTION
When you close the Ask webscocket nothing happens for one main reason where it is labeled as it is not running since we overwrite the main on open function we should be setting the on_open callback instead