### PR TITLE
fix(ltm): evaluate BasicRange.create() datetime defaults at call time

### DIFF
--- a/src/pieces_os_client/wrapper/basic_identifier/range.py
+++ b/src/pieces_os_client/wrapper/basic_identifier/range.py
@@ -61,7 +61,7 @@ class BasicRange(Basic):
 		RangeSnapshot.pieces_client.range_api.range_disassociate_conversation_grounding_temporal_range_workstreams(self.id, chat.id)
 
 	@staticmethod
-	def create(from_: Optional[datetime.datetime] = datetime.datetime.now() - datetime.timedelta(minutes=15), to: Optional[datetime.datetime] = datetime.datetime.now()) -> "BasicRange":
+	def create(from_: Optional[datetime.datetime] = None, to: Optional[datetime.datetime] = None) -> "BasicRange":
 		"""
 		Creates a new range based on a Range.
 
@@ -72,6 +72,10 @@ class BasicRange(Basic):
 		Returns:
 		- BasicRange: The created BasicRange instance.
 		"""
+		if from_ is None:
+			from_ = datetime.datetime.now() - datetime.timedelta(minutes=15)
+		if to is None:
+			to = datetime.datetime.now()
 		r = RangeSnapshot.pieces_client.ranges_api.ranges_create_new_range(
 			SeededRange(
 				var_from = GroupedTimestamp(value = from_) if from_ else None,


### PR DESCRIPTION
## Summary

`BasicRange.create()` evaluated `datetime.datetime.now()` directly in the default-argument expression for **both** `from_` and `to`. Python evaluates default expressions once, at function-definition time, so every call without explicit arguments received a timestamp frozen to module-import time.

`chat_enable_ltm()` calls `BasicRange.create()` with no arguments to attach a temporal range to a chat. With both defaults frozen at import, every chat received the same fixed window relative to process startup, regardless of when the user actually enabled LTM. Long-lived clients therefore retrieved progressively staler context.

This is the classic Python mutable-default-argument anti-pattern.

## Fix

Default both parameters to `None` and resolve to `now() - 15min` and `now()` respectively inside the body, so each call produces a live window.

## Test plan

- [x] py_compile passes
- [x] End-to-end verified via cli-agent (which vendors this SDK) on macOS 26.4.1, Pieces OS 12.3.11
- [ ] Reviewer confirms downstream re-vendoring path will pick this up automatically

A companion PR is open against `pieces-app/cli-agent` for the immediate vendored fix.